### PR TITLE
numbergen - change range bounds & add helper functions

### DIFF
--- a/numbergen/numbergen.smithy
+++ b/numbergen/numbergen.smithy
@@ -46,9 +46,9 @@ operation Random32 {
     output: U32
 }
 
-/// Input range for RandomInRange. Result will be >= min and < max
+/// Input range for RandomInRange, inclusive. Result will be >= min and <= max
 /// Example:
-///    random_in_range(RangeLimit{0,5}) returns one the values, 0, 1, 2, 3, or 4.
+///    random_in_range(RangeLimit{0,4}) returns one the values, 0, 1, 2, 3, or 4.
 structure RangeLimit {
     @required
     min: U32,

--- a/numbergen/rust/Cargo.toml
+++ b/numbergen/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-numbergen"
-version = "0.1.3"
+version = "0.1.4"
 description = "interface for actors to generate random numbers and guids (wasmcloud:builtin:numbergen)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"
@@ -25,16 +25,12 @@ futures = "0.3"
 serde = { version = "1.0" , features = ["derive"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
-
-[dependencies.wasmbus-rpc]
-version = "0.3"
-#path = "../../../weld/rpc-rs"
+wasmbus-rpc = "0.3"
 
 [dev-dependencies]
 base64 = "0.13"
 
 # build-dependencies needed for build.rs
-[build-dependencies.weld-codegen]
-version = "0.1"
-#path = "../../../weld/codegen"
+[build-dependencies]
+weld-codegen = "0.1"
 

--- a/numbergen/rust/src/lib.rs
+++ b/numbergen/rust/src/lib.rs
@@ -1,4 +1,43 @@
-//! org.wasmcloud.provider.builtin
+//! wasmcloud:builtin:numbergen
 
 mod numbergen;
 pub use numbergen::*;
+
+#[allow(unused_imports)]
+use wasmbus_rpc::RpcResult;
+
+// functions below are convenience wrappers around the interface invocations.
+
+#[cfg(target_arch = "wasm32")]
+/// Generate a v4-format guid in the form "nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn"
+/// where n is a lowercase hex digit and ann bits are random.
+pub async fn generate_guid() -> RpcResult<String> {
+    use wasmbus_rpc::{actor::prelude::WasmHost, Context};
+
+    let tx = WasmHost::to_provider("wasmcloud:builtin:numbergen", "default").unwrap();
+    let ctx = Context::default();
+    let ng = NumberGenSender::new(&tx);
+    ng.generate_guid(&ctx).await
+}
+
+#[cfg(target_arch = "wasm32")]
+/// Generate a random integer within an inclusive range. ( min <= n <= max )
+pub async fn random_in_range(min: u32, max: u32) -> RpcResult<u32> {
+    use wasmbus_rpc::{actor::prelude::WasmHost, Context};
+
+    let tx = WasmHost::to_provider("wasmcloud:builtin:numbergen", "default").unwrap();
+    let ctx = Context::default();
+    let ng = NumberGenSender::new(&tx);
+    ng.random_in_range(&ctx, &RangeLimit { min, max }).await
+}
+
+#[cfg(target_arch = "wasm32")]
+/// Generate a 32-bit random number
+pub async fn random_32() -> RpcResult<u32> {
+    use wasmbus_rpc::{actor::prelude::WasmHost, Context};
+
+    let tx = WasmHost::to_provider("wasmcloud:builtin:numbergen", "default").unwrap();
+    let ctx = Context::default();
+    let ng = NumberGenSender::new(&tx);
+    ng.random_32(&ctx).await
+}


### PR DESCRIPTION
change numbergen.range to be inclusive on both ends of range
add numbergen helper functions; 
bump numbergen crate to 0.1.4

Signed-off-by: steve <dev@somecool.net>