### PR TITLE
fix: timeout and rpc-timeout changed to ms

### DIFF
--- a/build/makefiles/actor.mk
+++ b/build/makefiles/actor.mk
@@ -73,7 +73,7 @@ push: $(DIST_WASM)
 
 # tell host to start an instance of the actor
 start:
-	$(WASH) ctl start actor $(REG_URL) --timeout 3
+	$(WASH) ctl start actor $(REG_URL) --timeout-ms 3000
 
 # NOT WORKING - live actor updates not working yet
 # update it (should update revision before doing this)
@@ -82,17 +82,17 @@ start:
 #	$(WASH) ctl update actor  \
 #        $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id") \
 #	    $(shell make --silent actor_id) \
-#	    $(REG_URL) --timeout 3
+#	    $(REG_URL) --timeout-ms 3000
 
 inventory:
 	$(WASH) ctl get inventory $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id")
 
 ifneq ($(wildcard test-options.json),)
 # if this is a test actor, run its start method
-# project makefile can set RPC_TEST_TIMEOUT to override default
-RPC_TEST_TIMEOUT ?= 2
+# project makefile can set RPC_TEST_TIMEOUT_MS to override default
+RPC_TEST_TIMEOUT_MS ?= 2000
 test::
-	$(WASH) call --test --data test-options.json --rpc-timeout $(RPC_TEST_TIMEOUT) \
+	$(WASH) call --test --data test-options.json --rpc-timeout-ms $(RPC_TEST_TIMEOUT_MS) \
 	    $(shell make --silent actor_id) \
 	    Testing.Start
 endif


### PR DESCRIPTION
Related to a naming convention change a week ago:
wasmCloud/wash#198

Signed-off-by: Bailey Hayes <bhayes@singlestore.com>