### PR TITLE
Adding config_json field to host data

### DIFF
--- a/core/wasmcloud-core.smithy
+++ b/core/wasmcloud-core.smithy
@@ -159,6 +159,12 @@ structure HostData {
     @serialization(name: "cluster_issuers")
     @n(11)
     clusterIssuers: ClusterIssuers,
+
+    /// Optional configuration JSON sent to a given link name of a provider
+    /// without an actor context
+    @serialization(name:"config_json")
+    @n(12)
+    configJson: String
 }
 
 list ClusterIssuers {


### PR DESCRIPTION
This field has been coming from the host for quite some time now (https://github.com/wasmCloud/wasmcloud-otp/blob/main/host_core/lib/host_core/host.ex#L235) and this PR just puts that field on the data structure so that we can update wasmbus-rpc to support this field.