### PR TITLE
Minor bumps for wasmbus-rpc

### DIFF
--- a/factorial/rust/Cargo.toml
+++ b/factorial/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-factorial"
-version = "0.2.0"
+version = "0.3.0"
 description = "Interface library for the wasmcloud factorial capability, wasmcloud:example:factorial"
 homepage = "https://wasmcloud.dev"
 repository = "https://github.com/wasmcloud/interfaces"
@@ -23,7 +23,7 @@ futures = "0.3"
 serde = { version = "1.0" , features = ["derive"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
-wasmbus-rpc = "0.5.2"
+wasmbus-rpc = "0.6"
 
 [dev-dependencies]
 base64 = "0.13"

--- a/httpclient/rust/Cargo.toml
+++ b/httpclient/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-httpclient"
-version = "0.2.0"
+version = "0.3.0"
 description = "interface for actors to issue http/https requests (wasmcloud:httpclient)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"
@@ -25,7 +25,7 @@ futures = "0.3"
 serde = { version = "1.0" , features = ["derive"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
-wasmbus-rpc = "0.5.2"
+wasmbus-rpc = "0.6"
 
 [dev-dependencies]
 base64 = "0.13"

--- a/httpserver/rust/Cargo.toml
+++ b/httpserver/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-httpserver"
-version = "0.2.0"
+version = "0.3.0"
 description = "interface for actors to receive http requests (wasmcloud:httpserver)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"
@@ -22,7 +22,7 @@ async-trait = "0.1"
 serde = { version = "1.0" , features = ["derive"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
-wasmbus-rpc = "0.5.2"
+wasmbus-rpc = "0.6"
 
 [dev-dependencies]
 base64 = "0.13"

--- a/keyvalue/rust/Cargo.toml
+++ b/keyvalue/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-keyvalue"
-version = "0.3.0"
+version = "0.4.0"
 description = "Key-Value store (wasmcloud:keyvalue)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"
@@ -23,7 +23,7 @@ serde = { version = "1.0" , features = ["derive"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
 log = "0.4"
-wasmbus-rpc = "0.5.2"
+wasmbus-rpc = "0.6"
 
 [dev-dependencies]
 base64 = "0.13"

--- a/logging/rust/Cargo.toml
+++ b/logging/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-logging"
-version = "0.2.1"
+version = "0.3.0"
 description = "interface for logging capability provider (wasmcloud:builtin:logging)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"

--- a/logging/rust/Cargo.toml
+++ b/logging/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-logging"
-version = "0.2.0"
+version = "0.2.1"
 description = "interface for logging capability provider (wasmcloud:builtin:logging)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"
@@ -26,7 +26,7 @@ serde = { version = "1.0" , features = ["derive"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
 cfg-if = "1.0"
-wasmbus-rpc = "0.5.2"
+wasmbus-rpc = "0.6"
 
 [dev-dependencies]
 base64 = "0.13"

--- a/messaging/rust/Cargo.toml
+++ b/messaging/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-messaging"
-version = "0.2.0"
+version = "0.3.0"
 description = "Interface library for the wasmCloud messaging capability, wasmcloud:messaging"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"
@@ -23,7 +23,7 @@ serde = { version = "1.0" , features = ["derive"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
 log = "0.4"
-wasmbus-rpc = "0.5.2"
+wasmbus-rpc = "0.6"
 
 [dev-dependencies]
 base64 = "0.13"

--- a/numbergen/rust/Cargo.toml
+++ b/numbergen/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-numbergen"
-version = "0.2.0"
+version = "0.3.0"
 description = "interface for actors to generate random numbers and guids (wasmcloud:builtin:numbergen)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"
@@ -25,7 +25,7 @@ futures = "0.3"
 serde = { version = "1.0" , features = ["derive"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
-wasmbus-rpc = "0.5.2"
+wasmbus-rpc = "0.6"
 
 [dev-dependencies]
 base64 = "0.13"

--- a/sqldb/rust/Cargo.toml
+++ b/sqldb/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-sqldb"
-version = "0.2.0"
+version = "0.3.0"
 description = "Interface for wasmCloud actors to connect to a relational database using the capability 'wasmcloud:sqldb'"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"
@@ -25,7 +25,7 @@ futures = "0.3"
 serde = { version = "1.0" , features = ["derive"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
-wasmbus-rpc = "0.5.2"
+wasmbus-rpc = "0.6"
 minicbor = { version = "0.11", features = ["derive", "std", "half"] }
 
 [dev-dependencies]


### PR DESCRIPTION
wasmbus-rpc needed a bump to `0.6.0`, and since it's causing breaking changes (if you have a different version of wasmbus than the interface then there are compile errors) I decided to do a minor bump.