### PR TITLE
Added actor ID to scale actor command

### DIFF
--- a/lattice-control/lattice-control-interface.smithy
+++ b/lattice-control/lattice-control-interface.smithy
@@ -394,6 +394,11 @@ structure ScaleActorCommand {
     @serialization(name: "actor_ref")
     actorRef: String,
 
+    /// Public Key ID of the actor to scale
+    @required
+    @serialization(name: "actor_id")
+    actorId: String,
+
     /// Host ID on which to scale this actor
     @required
     @serialization(name: "host_id")

--- a/lattice-control/rust/Cargo.toml
+++ b/lattice-control/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-lattice-control"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 homepage = "https://wasmcloud.dev"
 repository = "https://github.com/wasmCloud/interfaces"

--- a/lattice-control/rust/src/control.rs
+++ b/lattice-control/rust/src/control.rs
@@ -198,6 +198,9 @@ pub struct RemoveLinkDefinitionRequest {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ScaleActorCommand {
+    /// Public Key ID of the actor to scale
+    #[serde(default)]
+    pub actor_id: String,
     /// Reference for the actor. Can be any of the acceptable forms of unique identification
     #[serde(default)]
     pub actor_ref: String,


### PR DESCRIPTION
Unfortunately we did not include the actor ID into the scale actor command, which we've released. So this is another minor bump due to this being a breaking change