### PR TITLE
- add GetObjectInfo operation to retrieve object metadata

### DIFF
--- a/testing/rust/Cargo.toml
+++ b/testing/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-testing"
-version = "0.3.0"
+version = "0.3.1"
 description = "Testing interface (wasmcloud:testing)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"
@@ -23,11 +23,11 @@ regex = "1"
 serde = { version = "1.0" , features = ["derive"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
-wasmbus-rpc = "0.7"
+wasmbus-rpc = "0.7.5"
 
 [dev-dependencies]
 base64 = "0.13"
 
 # build-dependencies needed for build.rs
 [build-dependencies]
-weld-codegen = "0.3"
+weld-codegen = "0.3.3"

--- a/testing/rust/src/lib.rs
+++ b/testing/rust/src/lib.rs
@@ -4,7 +4,7 @@ mod testing;
 use serde::Serialize;
 use serde_json::json;
 pub use testing::*;
-use wasmbus_rpc::RpcResult;
+use wasmbus_rpc::error::RpcResult;
 
 impl Default for TestOptions {
     fn default() -> TestOptions {

--- a/testing/rust/src/testing.rs
+++ b/testing/rust/src/testing.rs
@@ -1,4 +1,4 @@
-// This file is generated automatically using wasmcloud/weld-codegen 0.3.0
+// This file is generated automatically using wasmcloud/weld-codegen 0.3.3
 
 #[allow(unused_imports)]
 use async_trait::async_trait;


### PR DESCRIPTION

- ObjectMetadata new fields: contentType, contentEncoding
- ObjectMetadata renamed 'size' to contentLength
- removed chunkSize parameter from GetObject operation

Signed-off-by: stevelr <steve@cosmonic.com>