### PR TITLE
Patch bump to release new interface readme's

### DIFF
--- a/blobstore/rust/Cargo.toml
+++ b/blobstore/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasmcloud-interface-blobstore"
-version = "0.3.0"
-description = "interface for accessing an object store"
+version = "0.3.1"
+description = "Interface for accessing an object store over the wasmcloud:blobstore contract"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"
 keywords = ["wasmcloud","wasm","actor","webassembly","capability"]
@@ -23,7 +23,7 @@ default = []
 [dependencies]
 async-trait = "0.1"
 futures = "0.3"
-serde = { version = "1.0" , features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
 wasmbus-rpc = "0.9"

--- a/factorial/rust/Cargo.toml
+++ b/factorial/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-factorial"
-version = "0.5.0"
+version = "0.5.1"
 description = "Interface library for the wasmcloud factorial capability, wasmcloud:example:factorial"
 homepage = "https://wasmcloud.dev"
 repository = "https://github.com/wasmcloud/interfaces"

--- a/httpclient/rust/Cargo.toml
+++ b/httpclient/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-httpclient"
-version = "0.6.0"
+version = "0.6.1"
 description = "interface for actors to issue http/https requests (wasmcloud:httpclient)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"

--- a/httpserver/rust/Cargo.toml
+++ b/httpserver/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-httpserver"
-version = "0.6.0"
+version = "0.6.1"
 description = "interface for actors to receive http requests (wasmcloud:httpserver)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"

--- a/keyvalue/rust/Cargo.toml
+++ b/keyvalue/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasmcloud-interface-keyvalue"
-version = "0.7.0"
-description = "Key-Value store (wasmcloud:keyvalue)"
+version = "0.7.1"
+description = "Interface for wasmCloud actors to access Key-Value stores (wasmcloud:keyvalue)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"
 keywords = ["wasmcloud","key-value","redis","capability"]

--- a/lattice-control/rust/Cargo.toml
+++ b/lattice-control/rust/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "wasmcloud-interface-lattice-control"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 homepage = "https://wasmcloud.dev"
 repository = "https://github.com/wasmCloud/interfaces"
-description = "This library allows different types of consumers to interact with the lattice control interface."
+description = "This library allows different types of consumers to interact with the lattice control interface over wasmcloud:latticecontrol"
 license = "Apache-2.0"
 documentation = "https://docs.rs/wasmcloud-interface-lattice-control"
 readme = "../README.md"

--- a/logging/rust/Cargo.toml
+++ b/logging/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-logging"
-version = "0.6.0"
+version = "0.6.1"
 description = "interface for logging capability provider (wasmcloud:builtin:logging)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"

--- a/messaging/rust/Cargo.toml
+++ b/messaging/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-messaging"
-version = "0.6.0"
+version = "0.6.1"
 description = "Interface library for the wasmCloud messaging capability, wasmcloud:messaging"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"

--- a/ml/rust/Cargo.toml
+++ b/ml/rust/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "wasmcloud_interface_mlinference"
-version = "0.2.0"
+version = "0.2.1"
 description = "Interface library for the MlInference capability"
-authors = [ "dev@example.com" ]
+authors = [ "wasmCloud Team" ]
 edition = "2021"
 license = "Apache-2.0"
 readme = "../README.md"
@@ -18,7 +18,7 @@ default = []
 
 [dependencies]
 async-trait = "0.1"
-serde = { version = "1.0" , features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 wasmbus-rpc = "0.9"
 

--- a/numbergen/rust/Cargo.toml
+++ b/numbergen/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-numbergen"
-version = "0.6.0"
+version = "0.6.1"
 description = "interface for actors to generate random numbers and guids (wasmcloud:builtin:numbergen)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"

--- a/sqldb/rust/Cargo.toml
+++ b/sqldb/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasmcloud-interface-sqldb"
-version = "0.6.0"
-description = "Interface for wasmCloud actors to connect to a relational database using the capability 'wasmcloud:sqldb'"
+version = "0.6.1"
+description = "Interface for wasmCloud actors to connect to a relational database using the capability wasmcloud:sqldb"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"
 keywords = ["wasmcloud","wasm","database","webassembly","capability"]

--- a/testing/rust/Cargo.toml
+++ b/testing/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-testing"
-version = "0.5.0"
+version = "0.5.1"
 description = "Testing interface (wasmcloud:testing)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"


### PR DESCRIPTION
This may or not be proper within the Rust ecosystem, but I think these README's provide enough value to not wait around until the next patch bump for each interface.