### PR TITLE
add registryType as required field to RegistryCredential

### DIFF
--- a/configservice/config-service.smithy
+++ b/configservice/config-service.smithy
@@ -65,5 +65,8 @@ structure RegistryCredential {
     token: String,
     /// If supplied, username and password will be used for HTTP Basic authentication
     username: String,
-    password: String
+    password: String,
+    /// The type of the registry (either "oci" or "bindle")
+    @required
+    registryType: String
 }

--- a/configservice/config-service.smithy
+++ b/configservice/config-service.smithy
@@ -65,6 +65,7 @@ structure RegistryCredential {
     token: String,
     /// If supplied, username and password will be used for HTTP Basic authentication
     username: String,
+    @sensitive
     password: String,
     /// The type of the registry (either "oci" or "bindle")
     @required

--- a/lattice-control/lattice-control-interface.smithy
+++ b/lattice-control/lattice-control-interface.smithy
@@ -684,6 +684,7 @@ structure RegistryCredential {
     token: String,
     /// If supplied, username and password will be used for HTTP Basic authentication
     username: String,
+    @sensitive
     password: String,
     /// The type of the registry (either "oci" or "bindle")
     @required

--- a/lattice-control/lattice-control-interface.smithy
+++ b/lattice-control/lattice-control-interface.smithy
@@ -684,6 +684,9 @@ structure RegistryCredential {
     token: String,
     /// If supplied, username and password will be used for HTTP Basic authentication
     username: String,
-    password: String
+    password: String,
+    /// The type of the registry (either "oci" or "bindle")
+    @required
+    registryType: String
 }
 

--- a/lattice-control/rust/Cargo.toml
+++ b/lattice-control/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-lattice-control"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 homepage = "https://wasmcloud.dev"
 repository = "https://github.com/wasmCloud/interfaces"


### PR DESCRIPTION
This is the first step to better registry config support. Following this, the lattice controller and control interface client will now include a `registryType` field, removing the need for the host to try to guess the type of registry server on config updates

Signed-off-by: Connor Smith <connor@cosmonic.com>