### PR TITLE
Added a simple impl for an OK http response

### DIFF
--- a/httpserver/rust/Cargo.toml
+++ b/httpserver/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-httpserver"
-version = "0.8.1"
+version = "0.8.2"
 description = "interface for actors to receive http requests (wasmcloud:httpserver)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"

--- a/httpserver/rust/src/lib.rs
+++ b/httpserver/rust/src/lib.rs
@@ -38,6 +38,16 @@ impl HttpResponse {
         })
     }
 
+    pub fn ok<S>(response: S) -> Result<HttpResponse, RpcError>
+    where
+        S: ToString,
+    {
+        Ok(HttpResponse {
+            body: response.to_string().as_bytes().to_vec(),
+            ..Default::default()
+        })
+    }
+
     /// Creates a response with a given status code, JSON-serialized payload, and headers specified by the header argument. Automatically includes the appropriate Content-Type header
     ///
     /// # Arguments


### PR DESCRIPTION
This PR adds a simple `impl` for the HTTPResponse object that just allows you to write something like:
```
HttpResponse::ok("Hello, World!")
```