### PR TITLE
Made HttpResponse::ok more efficient and friendly, bumped minor

### DIFF
--- a/httpserver/rust/Cargo.toml
+++ b/httpserver/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-httpserver"
-version = "0.8.2"
+version = "0.9.0"
 description = "interface for actors to receive http requests (wasmcloud:httpserver)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"
@@ -20,7 +20,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 async-trait = "0.1"
-serde = { version = "1.0" , features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
 wasmbus-rpc = "0.11.1"

--- a/httpserver/rust/src/lib.rs
+++ b/httpserver/rust/src/lib.rs
@@ -38,14 +38,11 @@ impl HttpResponse {
         })
     }
 
-    pub fn ok<S>(response: S) -> Result<HttpResponse, RpcError>
-    where
-        S: ToString,
-    {
-        Ok(HttpResponse {
-            body: response.to_string().as_bytes().to_vec(),
+    pub fn ok<S: Into<Vec<u8>>>(response: S) -> HttpResponse {
+        HttpResponse {
+            body: response.into(),
             ..Default::default()
-        })
+        }
     }
 
     /// Creates a response with a given status code, JSON-serialized payload, and headers specified by the header argument. Automatically includes the appropriate Content-Type header


### PR DESCRIPTION
My previous PR, #99 , improperly bumped a patch version when it should've been a minor revision. This PR properly bumps a minor bump for new functionality and makes the interface more efficient to not create a clone of the input