### PR TITLE
add logLevel to core interface

### DIFF
--- a/core/wasmcloud-core.smithy
+++ b/core/wasmcloud-core.smithy
@@ -180,6 +180,11 @@ structure HostData {
     @serialization(name: "structured_logging")
     @n(14)
     structuredLogging: Boolean,
+
+    /// The log level providers should log at
+    @serialization(name: "log_level")
+    @n(15)
+    logLevel: LogLevel
 }
 
 list ClusterIssuers {
@@ -194,6 +199,30 @@ map HostEnvValues {
     key: String,
     value: String,
 }
+
+@enum([
+    {
+        value: "trace",
+        name: "trace",
+    },
+    {
+        value: "debug",
+        name: "debug",
+    },
+    {
+        value: "info",
+        name: "info",
+    },
+    {
+        value: "warn",
+        name: "warn",
+    },
+    {
+        value: "error",
+        name: "error",
+    },
+])
+string LogLevel
 
 /// RPC message to capability provider
 @wasmbusData


### PR DESCRIPTION
## Feature or Problem
This adds a `logLevel` field to `HostData`, to indicate which level providers should log at. Until now, users could only set a log level for Rust providers, and it had to be done via the `RUST_LOG` env var.

## Related Issues
Resolves https://github.com/wasmCloud/weld/issues/145

## Release Information
N/A

## Consumer Impact
Nothing for now. Without changes to wasmbus-rpc and the host, this field has no impact

## Testing
See companion PR: https://github.com/wasmCloud/weld/pull/148

@jordan-rash I could use some help testing the changes to go. I'm not sure where changes unrelated to the log level came from or if they're correct. I generated these changes with `wash gen`, using a local copy of wash updated to use weld-codegen 0.7