### PR TITLE
Adds utc_now_millis to the builtin numbergen interface

### DIFF
--- a/numbergen/numbergen.smithy
+++ b/numbergen/numbergen.smithy
@@ -23,7 +23,7 @@ use org.wasmcloud.model#U64
     providerReceive: true )
 service NumberGen {
   version: "0.1",
-  operations: [ GenerateGuid, RandomInRange, Random32 ]
+  operations: [ GenerateGuid, RandomInRange, Random32, UtcNowMillis ]
 }
 
 ///
@@ -45,6 +45,11 @@ operation RandomInRange {
 /// Request a 32-bit random number
 operation Random32 {
     output: U32
+}
+
+/// Returns the current time in UTC as milliseconds since the epoch. This timestamp should never be guaranteed to be monotonic
+operation UtcNowMillis {
+    output: U64
 }
 
 /// Input range for RandomInRange, inclusive. Result will be >= min and <= max

--- a/numbergen/rust/Cargo.toml
+++ b/numbergen/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasmcloud-interface-numbergen"
-version = "0.9.0"
-description = "interface for actors to generate random numbers and guids (wasmcloud:builtin:numbergen)"
+version = "0.10.0"
+description = "Interface for actors to generate random numbers, guids, timestamps, etc"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"
 keywords = ["wasmcloud","wasm","actor","webassembly","capability"]
@@ -27,9 +27,6 @@ serde = { version = "1.0" , features = ["derive"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
 wasmbus-rpc = "0.13"
-
-[dev-dependencies]
-base64 = "0.13"
 
 # build-dependencies needed for build.rs
 [build-dependencies]

--- a/numbergen/rust/src/lib.rs
+++ b/numbergen/rust/src/lib.rs
@@ -32,3 +32,11 @@ pub async fn random_32() -> RpcResult<u32> {
     let ng = NumberGenSender::new();
     ng.random_32(&ctx).await
 }
+
+/// Obtains the number of milliseconds since the epoch. This time is not guaranteed to be monotonic
+#[cfg(target_arch = "wasm32")]
+pub async fn utc_now_millis() -> RpcResult<u64> {
+    let ctx = wasmbus_rpc::common::Context::default();
+    let ng = NumberGenSender::new();
+    ng.utc_now_millis(&ctx).await
+}


### PR DESCRIPTION
Adds the operation `utc_now_millis` to the interface definition for builtin number generation. Note that this is a breaking change and there is no _current_ host that supports this. A corresponding PR in the OTP host will need to be made. Note that the choice of timestamp implementation needs to be up to the host runtime.