### PR TITLE
Bumping keyvalue to newest wascap by way of wasmbus-rpc

### DIFF
--- a/keyvalue/rust/Cargo.toml
+++ b/keyvalue/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-interface-keyvalue"
-version = "0.10.0"
+version = "0.11.0"
 description = "Interface for wasmCloud actors to access Key-Value stores (wasmcloud:keyvalue)"
 repository = "https://github.com/wasmcloud/interfaces"
 homepage = "https://github.com/wasmcloud/wasmcloud"
@@ -24,10 +24,7 @@ serde = { version = "1.0" , features = ["derive"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
 log = "0.4"
-wasmbus-rpc = "0.13"
-
-[dev-dependencies]
-base64 = "0.13"
+wasmbus-rpc = "0.14"
 
 # build-dependencies needed for build.rs
 [build-dependencies]


### PR DESCRIPTION
Version bump so that anything built with this interface can use the latest wasmbus-rpc and therefore the latest wascap.