### PR TITLE
chore: add note about differences between stable and experimental ABIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ For more information on Smithy, see
 
 For more on wasmcloud, see
 
-- [wasmCloud](https://wasmcloud.dev)
+- [wasmCloud](https://wasmcloud.com)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
+> [!IMPORTANT]
+> The interfaces in this repo are defined in Smithy and used for RPC between actors and providers on the [stable ABI](https://wasmcloud.com/docs/hosts/abis/wasmbus/). For new providers and component actors, interfaces are defined using [WIT](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md), and codegen for providers is accomplished via the [wasmcloud-provider-wit-bindgen macro](https://github.com/wasmCloud/wasmCloud/tree/main/crates/provider-wit-bindgen). Note that support for WIT is considered **experimental** at this time.
+
 # wasmCloud API Interfaces
+
 This repository contains the wasmCloud contract interface definitions (defined in the _Smithy_ IDL) for those interfaces that are defined and supported by the wasmCloud team. These interfaces are definitely not the _only_ interfaces available, as teams and companies can create their own private or bespoke interfaces as desired.
 
 ## Smithy IDLs and Shared Libraries
@@ -6,7 +10,7 @@ This repository contains the wasmCloud contract interface definitions (defined i
 Each interface is defined in a file with the `.smithy` extension. If
 the folder contains a `codegen.toml` file,
 a library and/or html documentation can be
-automatically generated from the `.smithy` file. 
+automatically generated from the `.smithy` file.
 
 More information on code
 generation and the `codegen.toml` files is in the [weld
@@ -18,10 +22,11 @@ contains copies of the interfaces available for direct download, and
 html generated documentation.
 
 For more information on Smithy, see
- - [Smithy](https://awslabs.github.io/smithy/index.html) A language for
+
+- [Smithy](https://awslabs.github.io/smithy/index.html) A language for
   defining services and SDKs
- - [IDL specification](https://awslabs.github.io/smithy/1.0/spec/core/idl.html)
+- [IDL specification](https://awslabs.github.io/smithy/1.0/spec/core/idl.html)
 
 For more on wasmcloud, see
- - [wasmCloud](https://wasmcloud.dev)
 
+- [wasmCloud](https://wasmcloud.dev)


### PR DESCRIPTION
## Feature or Problem
This updates the README to distinguish between the stable and experimental ABIs

For a preview of the changes, see https://github.com/connorsmith256/interfaces/tree/chore/update-readme
